### PR TITLE
Do not preload & cache the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,10 @@ yarn add @devoxa/ip-geolocation
 ## Usage
 
 ```ts
-import { loadDatabase, geolocateIp } from '@devoxa/ip-geolocation'
-
-// Preload the geolocation database
-// Recommended, but not required. Will reduce the first call to `geolocateIp` by ~100ms
-await loadDatabase()
+import { geolocateIp } from '@devoxa/ip-geolocation'
 
 // Lookup an IP address
+// This will take about 50ms and use about 95MB of memory until garbage collected
 const result = await geolocateIp('69.10.63.243')
 // {
 //   continent: { code: 'NA', name: 'North America' },

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,35 @@
+// Test script to make sure that speed and garbage collection is as expected
+// > yarn build
+// > node scripts/postinstall.js
+// > node --expose-gc benchmark.js
+
+const { geolocateIp } = require('./dist/src/index')
+
+function printMemoryUsage() {
+  const used = process.memoryUsage().rss / 1024 / 1024
+  console.log(`Memory usage: ${Math.round(used * 100) / 100} MB`)
+}
+
+async function main() {
+  printMemoryUsage()
+
+  console.time('geolocateIp')
+  await geolocateIp('217.138.196.20')
+  console.timeEnd('geolocateIp')
+  printMemoryUsage()
+
+  console.time('geolocateIp')
+  await geolocateIp('217.138.196.20')
+  console.timeEnd('geolocateIp')
+  printMemoryUsage()
+
+  console.time('geolocateIp')
+  await geolocateIp('217.138.196.20')
+  console.timeEnd('geolocateIp')
+  printMemoryUsage()
+
+  global.gc()
+  setTimeout(() => printMemoryUsage(), 1000)
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "prettier": "@devoxa/prettier-config",
   "dependencies": {
-    "maxmind": "^4.1.3"
+    "mmdb-lib": "^1.3.0"
   },
   "devDependencies": {
     "@devoxa/eslint-config": "^2.0.5",

--- a/tests/__snapshots__/index.spec.ts.snap
+++ b/tests/__snapshots__/index.spec.ts.snap
@@ -95,5 +95,3 @@ Object {
   },
 }
 `;
-
-exports[`ip-geolocation errors if the database does not exist 1`] = `[Error: Database file at foo.mmdb does not exist]`;

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,4 +1,4 @@
-import { geolocateIp, loadDatabase } from '../src/index'
+import { geolocateIp } from '../src/index'
 
 const PROPERTY_MATCHER = {
   city: {
@@ -11,18 +11,6 @@ const PROPERTY_MATCHER = {
 }
 
 describe('ip-geolocation', () => {
-  it('errors if the database does not exist', async () => {
-    let error
-
-    try {
-      await loadDatabase('foo.mmdb')
-    } catch (err) {
-      error = err
-    }
-
-    expect(error).toMatchSnapshot()
-  })
-
   it('can geolocate ip address from the USA', async () => {
     expect(await geolocateIp('69.10.63.243')).toMatchSnapshot(PROPERTY_MATCHER)
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3071,14 +3071,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-maxmind@^4.1.3:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/maxmind/-/maxmind-4.3.2.tgz#e11fcf96a0c3ecf96a78839e3b808ab769fa4e78"
-  integrity sha512-cZ4nsLeYbFWVbhkBU3VTPJ10SDCGAKQ8kGpuYh1AesN4NvMQGab+NIBqcReA4dxQqPjA/CM6e6mQGCusvUSp6Q==
-  dependencies:
-    mmdb-lib "1.3.0"
-    tiny-lru "7.0.6"
-
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -3158,7 +3150,7 @@ mkdirp@1.x:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mmdb-lib@1.3.0:
+mmdb-lib@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/mmdb-lib/-/mmdb-lib-1.3.0.tgz#9e19feab91063636546bb28a44d728e283a24ee4"
   integrity sha512-KrRrAuC+X9ZkkPZNsqgHUGrop28vcmqISILyUXG0xOYt82ObU9d9XowVsjOVOr5CegyjrkmxEN5ut9r576vq2g==
@@ -4178,11 +4170,6 @@ throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
-
-tiny-lru@7.0.6:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-7.0.6.tgz#b0c3cdede1e5882aa2d1ae21cb2ceccf2a331f24"
-  integrity sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
While nice for performance of subsequent lookups, this was really bad for memory usage and increased the footprint of each process using the module by ~95MB.